### PR TITLE
Fixing flatMap4 not declaring the fourth dependency while creating new node

### DIFF
--- a/src/main/java/com/twitter/nodes/Node.java
+++ b/src/main/java/com/twitter/nodes/Node.java
@@ -1059,7 +1059,7 @@ public abstract class Node<Resp> extends Function0<Future<Resp>> {
       String name,
       Node<A> aNode, Node<B> bNode, Node<C> cNode, Node<D> dNode,
       Function4<Future<T>, A, B, C, D> func) {
-    return new Node<T>(name, aNode, bNode, cNode) {
+    return new Node<T>(name, aNode, bNode, cNode, dNode) {
       @Override
       protected Future<T> evaluate() throws Exception {
         return func.apply(aNode.emit(), bNode.emit(), cNode.emit(), dNode.emit());

--- a/src/test/java/com/twitter/nodes/NodeTest.java
+++ b/src/test/java/com/twitter/nodes/NodeTest.java
@@ -354,6 +354,39 @@ public class NodeTest extends NodeTestBase {
   }
 
   @Test
+  public void testFlatMap2() throws Exception {
+      Node<Integer> first = Node.value(100);
+      Node<Integer> second = Node.value(200);
+      Node<Integer> flatMappedNode = Node.flatMap2("FlatMap2", first, second,
+              (result1, result2) -> Future.value(result1 + result2));
+
+      assertEquals(new Integer(300), resultFromNode(flatMappedNode));
+  }
+
+  @Test
+  public void testFlatMap3() throws Exception {
+      Node<Integer> first = Node.value(100);
+      Node<Integer> second = Node.value(200);
+      Node<Integer> third = Node.value(300);
+      Node<Integer> flatMappedNode = Node.flatMap3("FlatMap3", first, second, third,
+              (result1, result2, result3)->Future.value(result1 + result2 + result3));
+
+      assertEquals(new Integer(600), resultFromNode(flatMappedNode));
+  }
+
+  @Test
+  public void testFlatMap4() throws Exception {
+      Node<Integer> first = Node.value(100);
+      Node<Integer> second = Node.value(200);
+      Node<Integer> third = Node.value(300);
+      Node<Integer> fourth = Node.value(400);
+      Node<Integer> flatMappedNode = Node.flatMap4("FlatMap4", first, second, third, fourth,
+              (result1, result2, result3, result4)->Future.value(result1 + result2 + result3 + result4));
+
+      assertEquals(new Integer(1000), resultFromNode(flatMappedNode));
+  }
+
+  @Test
   public void testWhen() throws Exception {
     Node<String> node = Node.value("condition was true");
     assertEquals("condition was true", resultFromNode(node.when(Node.TRUE)));


### PR DESCRIPTION
Fixing flatMap4 not declaring the fourth dependency while creating new node